### PR TITLE
S390x

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ steps:
   image: rancher/hardened-build-base:v1.16.6b7
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
+  - make DRONE_TAG=${DRONE_TAG} image-push
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
@@ -74,7 +74,7 @@ steps:
   failure: ignore
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
+  - make DRONE_TAG=${DRONE_TAG} image-push
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password

--- a/.drone.yml
+++ b/.drone.yml
@@ -49,7 +49,7 @@ volumes:
 ---
 kind: pipeline
 type: docker
-name: linux-amd64
+name: linux-s390x
 
 platform:
   os: linux

--- a/.drone.yml
+++ b/.drone.yml
@@ -46,5 +46,72 @@ volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
+---
+kind: pipeline
+type: docker
+name: linux-amd64
 
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  arch: s390x
+
+steps:
+- name: build
+  pull: always
+  image: rancher/hardened-build-base:v1.16.9b7
+  failure: ignore
+  commands:
+  - make DRONE_TAG=${DRONE_TAG}
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+- name: publish
+  image: rancher/hardened-build-base:v1.16.9b7
+  failure: ignore
+  commands:
+  - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+    DOCKER_USERNAME:
+      from_secret: docker_username
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+---
+kind: pipeline
+type: docker
+name: manifest
+platform:
+  os: linux
+  arch: amd64
+steps:
+- name: push
+  image: plugins/manifest:1.2.3
+  settings:
+    password:
+      from_secret: docker_password
+    username:
+      from_secret: docker_username
+    spec: manifest.tmpl
+    ignore_missing: true
+  when:
+    event:
+    - tag
+depends_on:
+- linux-amd64
+- linux-s390x
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.16.7b7
+ARG GO_IMAGE=rancher/hardened-build-base:v1.16.9b7
 # We need iptables and ip6tables. We will get them from the hardened kube-proxy image
 ARG KUBE_PROXY_IMAGE=rancher/hardened-kube-proxy:v1.21.3-build20210716
 
@@ -30,7 +30,9 @@ RUN git checkout tags/${TAG} -b ${TAG}
 RUN GOARCH=${ARCH} GO_LDFLAGS="-linkmode=external -X ${PKG}/pkg/version.VERSION=${TAG}" \
     go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o . ./...
 RUN go-assert-static.sh node-cache
-RUN go-assert-boring.sh node-cache
+RUN if [ "${ARCH}" != "s390x" ]; then \
+      go-assert-boring.sh node-cache; \
+    fi
 RUN install -s node-cache /usr/local/bin
 
 FROM ubi as dnsNodeCache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
 ARG GO_IMAGE=rancher/hardened-build-base:v1.16.9b7
-# We need iptables and ip6tables. We will get them from the hardened kube-proxy image
-ARG KUBE_PROXY_IMAGE=rancher/hardened-kube-proxy:v1.21.3-build20210716
+# We need iptables and ip6tables. We will get them from the hardened kubernetes image
+ARG KUBERNETES=rancher/hardened-kubernetes:v1.22.3-rke2r1-build20211028
 
 ARG TAG="1.19.1"
 ARG ARCH="amd64"
 FROM ${UBI_IMAGE} as ubi
-FROM ${KUBE_PROXY_IMAGE} as kube-proxy
+FROM ${KUBERNETES} as kubernetes
 FROM ${GO_IMAGE} as base-builder
 # setup required packages
 RUN set -x \
@@ -40,6 +40,6 @@ RUN microdnf update -y && \
     microdnf install nc which && \
     rm -rf /var/cache/yum
 COPY --from=dnsNodeCache-builder /usr/local/bin/node-cache /node-cache
-COPY --from=kube-proxy /usr/sbin/ip* /usr/sbin/
-COPY --from=kube-proxy /usr/sbin/xtables* /usr/sbin/
+COPY --from=kubernetes /usr/sbin/ip* /usr/sbin/
+COPY --from=kubernetes /usr/sbin/xtables* /usr/sbin/
 ENTRYPOINT ["/node-cache"]

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ image-build:
 		--pull \
 		--build-arg PKG=$(PKG) \
 		--build-arg SRC=$(SRC) \
+		--build-arg ARCH=$(ARCH) \
 		--build-arg TAG=$(TAG:$(BUILD_META)=) \
 		--tag $(ORG)/hardened-dns-node-cache:$(TAG) \
 		--tag $(ORG)/hardened-dns-node-cache:$(TAG)-$(ARCH) \

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -1,0 +1,12 @@
+image: rancher/hardened-dns-node-cache:{{build.tag}}
+manifests:
+  -
+    image: rancher/hardened-dns-node-cache:{{build.tag}}-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: rancher/hardened-dns-node-cache:{{build.tag}}-s390x
+    platform:
+      architecture: s390x
+      os: linux


### PR DESCRIPTION
- Compile and create docker image in a s390x drone node
- Use drone manifest plugin to create a multi-architecture docker image
- Don't block pipeline if s390x build fail (just ignore)
- Use kubernetes image instead of kube-proxy, since kube-proxy image is not used anymore