### PR TITLE
Fix bug for the image scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,5 @@ image-manifest:
 
 .PHONY: image-scan
 image-scan:
-	trivy image --severity $(SEVERITIESdnsNodeCache) --no-progress --ignore-unfixed $(ORG)/hardened-dns-node-cache:$(TAG)
+	trivy image --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-dns-node-cache:$(TAG)
 


### PR DESCRIPTION
`$(SEVERITIESdnsNodeCache)` is a variable which does not exist. Therefore, drone warns with:
```
unknown severity option: unknown severity: --NO-PROGRESS
```