### PR TITLE
Fix drone yaml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -47,6 +47,12 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/main
+      - refs/pull/**
+      - refs/tags/*
 
 volumes:
 - name: docker
@@ -71,6 +77,13 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+      include:
+      - refs/heads/main
+      - refs/pull/**
+      - refs/tags/*
+
 
 - name: publish
   image: rancher/hardened-build-base:v1.20.7b3


### PR DESCRIPTION
Drone yaml file is currently wrong an for amd64, it clones the project and then runs the scan without running build, thus miserably failing: https://drone-publish.rancher.io/rancher/image-build-dns-nodecache/43