### PR TITLE
Bump dns nodecache version to 1.22.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_IMAGE=rancher/hardened-build-base:v1.20.7b3
 # We need iptables and ip6tables. We will get them from the hardened kubernetes image
 ARG KUBERNETES=rancher/hardened-kubernetes:v1.29.1-rke2r1-build20240117
 
-ARG TAG="1.22.28"
+ARG TAG=1.22.28
 ARG ARCH="amd64"
 FROM ${BCI_IMAGE} as bci
 FROM ${KUBERNETES} as kubernetes
@@ -20,7 +20,7 @@ FROM base as builder
 ARG SRC=github.com/kubernetes/dns
 ARG PKG=github.com/kubernetes/dns
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
-ARG TAG
+ARG TAG=1.22.28
 ARG ARCH
 WORKDIR $GOPATH/src/${PKG}
 RUN git tag --list


### PR DESCRIPTION



<Actions>
    <action id="5dd9e9c474d8b279a42a1399c469f641195a032d7c3156f1a2ff5e30eec810a9">
        <h3>Update dns nodecache version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump to latest dns nodecache version in Dockerfile</summary>
            <p>changed lines [6 23] of file &#34;/tmp/updatecli/github/rancher/image-build-dns-nodecache/Dockerfile&#34;</p>
            <details>
                <summary>1.22.28</summary>
                <pre>&#xA;Release published on the 2023-11-15 18:25:04 +0000 UTC at the url https://github.com/kubernetes/dns/releases/tag/1.22.28&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;* Bump debian BASEIMAGE for dnsmasq by @DamianSawicki in https://github.com/kubernetes/dns/pull/611&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/kubernetes/dns/compare/1.22.27...1.22.28</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

