### PR TITLE
Use updatecli to update dns nodecache version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ARG GO_IMAGE=rancher/hardened-build-base:v1.20.7b3
 # We need iptables and ip6tables. We will get them from the hardened kubernetes image
 ARG KUBERNETES=rancher/hardened-kubernetes:v1.29.1-rke2r1-build20240117
 
-ARG TAG="1.22.28"
 ARG ARCH="amd64"
 FROM ${BCI_IMAGE} as bci
 FROM ${KUBERNETES} as kubernetes
@@ -20,7 +19,7 @@ FROM base as builder
 ARG SRC=github.com/kubernetes/dns
 ARG PKG=github.com/kubernetes/dns
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
-ARG TAG
+ARG TAG="1.22.28"
 ARG ARCH
 WORKDIR $GOPATH/src/${PKG}
 RUN git tag --list

--- a/updatecli/updatecli.d/updatednsnodecache.yaml
+++ b/updatecli/updatecli.d/updatednsnodecache.yaml
@@ -1,0 +1,63 @@
+---
+name: "Update dns nodecache version" 
+
+sources:
+ k8sdns:
+   name: Get dns nodecache version
+   kind: githubrelease
+   spec:
+     owner: kubernetes
+     repository: dns
+     token: '{{ requiredEnv .github.token }}'
+     typefilter:
+       release: true
+       draft: false
+       prerelease: false
+     versionfilter:
+       kind: latest
+
+targets:
+  dockerfile:
+    name: "Bump to latest dns nodecache version in Dockerfile"
+    kind: dockerfile
+    scmid: default
+    sourceid: k8sdns
+    spec:
+      file: "Dockerfile"
+      instruction:
+        keyword: "ARG"
+        matcher: "TAG"
+
+  makefile:
+    name: "Bump to latest dns nodecache version in Makefile"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: Makefile
+      matchpattern: '(?m)^TAG \?\= (.*)'
+      replacepattern: 'TAG ?= {{ source "k8sdns" }}$$(BUILD_META)'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.user }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+
+actions:
+    default:
+        title: 'Bump dns nodecache version to {{ source "k8sdns" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created
+        scmid: default

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -3,3 +3,6 @@ github:
   email: "41898282+github-actions[bot]@users.noreply.github.com"
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
+  repository: "image-build-dns-nodecache"
+  branch: "main"
+  owner: "rancher"


### PR DESCRIPTION
Use updatecli to bump version.

Seems to work: https://github.com/rancher/image-build-dns-nodecache/pull/28