### PR TITLE
Fix updatecli after GHA migration

### DIFF
--- a/updatecli/updatecli.d/updatednsnodecache.yaml
+++ b/updatecli/updatecli.d/updatednsnodecache.yaml
@@ -35,8 +35,8 @@ targets:
     disablesourceinput: true
     spec:
       file: Makefile
-      matchpattern: '(?m)^TAG \?\= (.*)'
-      replacepattern: 'TAG ?= {{ source "k8sdns" }}$$(BUILD_META)'
+      matchpattern: '(?m)^TAG \:\= (.*)'
+      replacepattern: 'TAG := {{ source "k8sdns" }}$$(BUILD_META)'
 
 scms:
   default:


### PR DESCRIPTION
Now there are two TAGs in Makefile and we just want to change the one with the symbol ":"

Similar to: https://github.com/rancher/image-build-k8s-metrics-server/pull/53