### PR TITLE
updatecli: use `semver` versionfilter

### DIFF
--- a/updatecli/updatecli.d/updatednsnodecache.yaml
+++ b/updatecli/updatecli.d/updatednsnodecache.yaml
@@ -14,7 +14,7 @@ sources:
        draft: false
        prerelease: false
      versionfilter:
-       kind: latest
+       kind: semver
 
 targets:
   dockerfile:


### PR DESCRIPTION
Version bump PRs should use the semver instead of the latest tag

Issue: https://github.com/rancher/rke2/issues/6402