### PR TITLE
Switch base image from bci-busybox to bci-nano

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
+ARG BCI_IMAGE=registry.suse.com/bci/bci-nano:16.0
 ARG GO_IMAGE=rancher/hardened-build-base:v1.25.11b1
 
 # Image that provides cross compilation tooling.


### PR DESCRIPTION
## What
Switch the runtime base image from `registry.suse.com/bci/bci-busybox` to `registry.suse.com/bci/bci-nano:16.0`.

## Why
This image's final stage runs a statically-linked binary as its entrypoint and does not depend on a shell or busybox applets at runtime (any required iptables/userspace already comes from k3s-root where applicable). `bci-nano` is the most minimal BCI base and carries a smaller package/CVE surface. This mirrors the pattern already adopted by [`image-build-kubernetes`](https://github.com/rancher/image-build-kubernetes), which builds on `bci-nano:16.0`.

## Notes
- The `Makefile` does not pass `--build-arg BCI_IMAGE`, so the new `ARG` default is what gets used.
- `updatecli` only manages `GO_IMAGE` (build base), not `BCI_IMAGE`, so this won't be auto-reverted.
- Validated with `docker build --check` (no warnings) and confirmed `bci-nano:16.0` is pullable.

🤖 Generated with the GitHub Copilot CLI.
