### PR TITLE
Fix golang.org/x/net CVEs via go.mod override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BCI_IMAGE=registry.suse.com/bci/bci-busybox
-ARG GO_IMAGE=rancher/hardened-build-base:v1.25.11b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.25.12b1
 
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.6.1 AS xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,6 @@ WORKDIR $GOPATH/src/${PKG}
 RUN git tag --list
 RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
-RUN go mod edit -replace github.com/coredns/coredns=github.com/coredns/coredns@v1.14.3 && \
-    go mod edit -replace google.golang.org/grpc=google.golang.org/grpc@v1.79.3 && \
-    go mod edit -replace go.opentelemetry.io/otel/sdk=go.opentelemetry.io/otel/sdk@v1.43.0 && \
-    go mod tidy && go mod vendor
 COPY go-mod-overrides ./go-mod-overrides
 RUN go-mod-overrides.sh ./go-mod-overrides
 RUN xx-go --wrap &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN go mod edit -replace github.com/coredns/coredns=github.com/coredns/coredns@v
     go mod edit -replace google.golang.org/grpc=google.golang.org/grpc@v1.79.3 && \
     go mod edit -replace go.opentelemetry.io/otel/sdk=go.opentelemetry.io/otel/sdk@v1.43.0 && \
     go mod tidy && go mod vendor
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 RUN xx-go --wrap &&\
     GO_LDFLAGS="-linkmode=external -X ${PKG}/pkg/version.VERSION=${TAG}" \
     go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o . ./...

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,20 @@
+# go-mod-overrides
+#
+# Tracks go.mod overrides applied on top of the upstream module to keep this
+# image CVE-free, even when upstream has not yet bumped the affected dependency.
+# Each non-comment line is passed verbatim to `go mod edit` at build time by the
+# shared scripts/go-mod-overrides.sh that ships in rancher/hardened-build-base.
+# Reference a CVE/advisory per entry so we know when it can be dropped (i.e. once
+# upstream catches up).
+#
+# Supported (anything `go mod edit` accepts), e.g.:
+#   -replace <old>[=<new>][@<version>]
+#   -require <path>@<version>
+#   -exclude <path>@<version>
+#   -dropreplace <path>[@<version>]
+
+# golang.org/x/net — pin to a patched release until upstream bumps it.
+#   CVE-2026-33814 — net/http2 DoS via malformed SETTINGS_MAX_FRAME_SIZE (fixed in v0.53.0)
+#   CVE-2026-39821 — x/net/idna Punycode privilege escalation           (fixed in v0.55.0)
+# Drop once upstream requires golang.org/x/net >= v0.55.0.
+-replace golang.org/x/net=golang.org/x/net@v0.55.0

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,20 +1,3 @@
-# go-mod-overrides
-#
-# Tracks go.mod overrides applied on top of the upstream module to keep this
-# image CVE-free, even when upstream has not yet bumped the affected dependency.
-# Each non-comment line is passed verbatim to `go mod edit` at build time by the
-# shared scripts/go-mod-overrides.sh that ships in rancher/hardened-build-base.
-# Reference a CVE/advisory per entry so we know when it can be dropped (i.e. once
-# upstream catches up).
-#
-# Supported (anything `go mod edit` accepts), e.g.:
-#   -replace <old>[=<new>][@<version>]
-#   -require <path>@<version>
-#   -exclude <path>@<version>
-#   -dropreplace <path>[@<version>]
-
-# golang.org/x/net — pin to a patched release until upstream bumps it.
-#   CVE-2026-33814 — net/http2 DoS via malformed SETTINGS_MAX_FRAME_SIZE (fixed in v0.53.0)
-#   CVE-2026-39821 — x/net/idna Punycode privilege escalation           (fixed in v0.55.0)
+# golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode).
 # Drop once upstream requires golang.org/x/net >= v0.55.0.
 -replace golang.org/x/net=golang.org/x/net@v0.55.0

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -3,6 +3,7 @@
 -replace golang.org/x/net=golang.org/x/net@v0.55.0
 
 # Ported from the Dockerfile's inline `go mod edit` block; may no longer be needed.
+# Remove when upstream node-cache > 1.26.8 is tagged.
 -replace github.com/coredns/coredns=github.com/coredns/coredns@v1.14.3
 -replace google.golang.org/grpc=google.golang.org/grpc@v1.79.3
 -replace go.opentelemetry.io/otel/sdk=go.opentelemetry.io/otel/sdk@v1.43.0

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -5,5 +5,6 @@
 # Ported from the Dockerfile's inline `go mod edit` block; may no longer be needed.
 # Remove when upstream node-cache > 1.26.8 is tagged.
 -replace github.com/coredns/coredns=github.com/coredns/coredns@v1.14.3
+# Remove when upstream coredns 1.14.3 is released.
 -replace google.golang.org/grpc=google.golang.org/grpc@v1.79.3
 -replace go.opentelemetry.io/otel/sdk=go.opentelemetry.io/otel/sdk@v1.43.0

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,3 +1,8 @@
 # golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode).
 # Drop once upstream requires golang.org/x/net >= v0.55.0.
 -replace golang.org/x/net=golang.org/x/net@v0.55.0
+
+# Ported from the Dockerfile's inline `go mod edit` block; may no longer be needed.
+-replace github.com/coredns/coredns=github.com/coredns/coredns@v1.14.3
+-replace google.golang.org/grpc=google.golang.org/grpc@v1.79.3
+-replace go.opentelemetry.io/otel/sdk=go.opentelemetry.io/otel/sdk@v1.43.0


### PR DESCRIPTION
## Problem

The `hardened-dns-node-cache` image ships HIGH `golang.org/x/net` CVEs that are not yet fixed in the pinned upstream release:

- **CVE-2026-33814** — `net/http2` DoS via a malformed `SETTINGS_MAX_FRAME_SIZE` frame (fixed in `golang.org/x/net` v0.53.0)
- **CVE-2026-39821** — `x/net/idna` privilege escalation via incorrect Punycode label processing (fixed in `golang.org/x/net` v0.55.0)

## Fix

Use the shared, declarative go.mod override mechanism added to `rancher/hardened-build-base` in rancher/image-build-base#105:

- Add a repo-root **`go-mod-overrides`** file pinning `golang.org/x/net` to `v0.55.0` (covers both CVEs). Each entry references the CVE so it can be dropped once upstream catches up.
- Wire the Dockerfile builder to run the shared `go-mod-overrides.sh` (ships in `hardened-build-base`) so the pin is applied before the binaries are built.

## Note

The shared `go-mod-overrides.sh` was only just merged into `rancher/image-build-base` (#105) and is **not yet present in a released `hardened-build-base` tag**. This PR is intentionally opened ahead of that: it will build green once a new `hardened-build-base` tag is cut with the script and the `GO_IMAGE` in this repo is bumped to it.

CVE source: rke2-toolbox scan report `scan-20260708-1`.
