### PR TITLE
Override github.com/DataDog/dd-trace-go/v2@v2.8.1 to fix CVE-2026-50274

### DIFF
--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -17,3 +17,7 @@
 # Remove when upstream coredns 1.14.3 is released.
 -replace google.golang.org/grpc=google.golang.org/grpc@v1.79.3
 -replace go.opentelemetry.io/otel/sdk=go.opentelemetry.io/otel/sdk@v1.43.0
+
+# github.com/DataDog/dd-trace-go/v2: CVE-2026-50274 (HIGH) — improper parsing of W3C baggage headers may lead to DoS.
+# Drop once upstream node-cache requires github.com/DataDog/dd-trace-go/v2 >= v2.8.1.
+-replace github.com/DataDog/dd-trace-go/v2=github.com/DataDog/dd-trace-go/v2@v2.8.1


### PR DESCRIPTION
## Summary

Adds a `go-mod-overrides` entry to pin `github.com/DataDog/dd-trace-go/v2` to `v2.8.1`, fixing a HIGH CVE flagged in the latest hardened-dns-node-cache image scan.

## CVE

- **CVE-2026-50274 (HIGH)**: dd-trace-go improper parsing of W3C baggage headers may lead to a denial of service.
- **Vulnerable module**: `github.com/DataDog/dd-trace-go/v2`
- **Installed version**: v2.7.1
- **Fixed version**: v2.8.1

## Scan source

- rke2-toolbox scan `scan-20260716-1`
- Image: `registry.rancher.com/rancher/hardened-dns-node-cache:1.26.8-build20260709`

## Notes

This uses the `go-mod-overrides` mechanism (introduced in #177 and applied in the Dockerfile via `go-mod-overrides.sh ./go-mod-overrides`) rather than editing any `go.mod` directly. The override should be dropped once upstream node-cache requires `github.com/DataDog/dd-trace-go/v2` >= v2.8.1.
